### PR TITLE
authenticate and authorize user for repositories controller

### DIFF
--- a/lib/funnel/platter.ex
+++ b/lib/funnel/platter.ex
@@ -49,6 +49,24 @@ defmodule Funnel.Platter do
     end)
   end
 
+  @spec user_has_git_hub_repository_access?(binary, integer) :: boolean
+  def user_has_git_hub_repository_access?(user_access_token, git_hub_id) do
+    user_access_token
+    |> get_user_repository_git_hub_ids()
+    |> Enum.member?(git_hub_id)
+  end
+
+  @spec get_user_repository_git_hub_ids(binary) :: list(integer)
+  defp get_user_repository_git_hub_ids(user_access_token) do
+    get_user_installations(user_access_token)
+    |> Enum.map(fn(installation) ->
+      get_user_repositories_for_installation(installation["id"], user_access_token)
+      |> Enum.map(fn(el) -> el["id"]
+      end)
+    end)
+    |> List.flatten
+  end
+
   @spec extract_repository_details_attrs(map, number) :: %{owner: binary, name: binary, git_hub_installation_id: number}
   defp extract_repository_details_attrs(response, installation_id) do
     %{ owner: response["owner"]["login"], name: response["name"], git_hub_installation_id: installation_id }

--- a/lib/funnel_web/controllers/repositories_controller.ex
+++ b/lib/funnel_web/controllers/repositories_controller.ex
@@ -7,44 +7,39 @@ defmodule FunnelWeb.RepositoriesController do
   alias Funnel.Investigator
 
   plug :scrub_params, "repository" when action in [:update]
+  plug :git_hub_authenticate
+  plug :git_hub_authorize_repository when action in [:show, :edit, :update]
 
   def index(conn, _params) do
-    alias FunnelWeb.Router.Helpers
-    case get_session(conn, :git_hub_access_token) do
-      nil ->
-        redirect(conn, to: Helpers.auth_path(conn, :login))
-      token ->
-        repositories = Platter.get_all_user_repositories(token)
-        render(conn, "index.html", repositories: repositories)
-    end
+    repositories = Platter.get_all_user_repositories(conn.assigns[:git_hub_access_token])
+    render(conn, "index.html", repositories: repositories)
   end
 
-  def show(conn, %{"id" => id}) do
-    repository = Repo.preload(GitHub.get_repository!(id), :strategy)
-    render(conn, "show.html", repository: repository)
+  def show(conn, _params) do
+    render(conn, "show.html")
   end
 
-  def edit(conn, %{"id" => id}) do
-    repository = Repo.preload(GitHub.get_repository!(id), :strategy)
+  def edit(conn, _params) do
     strategies = Git.list_strategies()
-    changeset = GitHub.change_repository(repository)
+    changeset = GitHub.change_repository(conn.assigns[:repository])
     render(
       conn,
       "edit.html",
-      [repository: repository, strategies: strategies, changeset: changeset]
+      [strategies: strategies, changeset: changeset]
     )
   end
 
-  def update(conn, %{"id" => id, "repository" => repository_params}) do
-    repository = Repo.preload(GitHub.get_repository!(id), :strategy)
-    strategies = Git.list_strategies()
-    case GitHub.update_repository(repository, repository_params) do
+  def update(conn, %{"repository" => repository_params}) do
+    case GitHub.update_repository(conn.assigns[:repository], repository_params) do
       {:ok, repository} ->
         Investigator.investigate_repository(repository)
         conn
+        |> assign(:repository, repository)
         |> put_flash(:info, "Repository updated successfully.")
         |> redirect(to: repositories_path(conn, :show, repository))
       {:error, %Ecto.Changeset{} = changeset} ->
+        strategies = Git.list_strategies()
+        repository = conn.assigns[:repository]
         render(
         conn,
         "edit.html",
@@ -52,4 +47,37 @@ defmodule FunnelWeb.RepositoriesController do
         )
     end
   end
+
+  defp git_hub_authenticate(conn, _) do
+    alias FunnelWeb.Router.Helpers
+    case get_session(conn, :git_hub_access_token) do
+      nil ->
+        conn
+        |> put_flash(:info, "Please authenticate with GitHub")
+        |> redirect(to: Helpers.auth_path(conn, :login))
+        |> halt()
+      token ->
+        conn
+        |> assign(:git_hub_access_token, token)
+    end
+  end
+
+  defp git_hub_authorize_repository(conn, _) do
+    alias FunnelWeb.ErrorView
+    token = conn.assigns[:git_hub_access_token]
+    id = conn.params["id"]
+    repository = Repo.preload(GitHub.get_repository!(id), :strategy)
+    case Platter.user_has_git_hub_repository_access?(token, repository.git_hub_id) do
+      true ->
+        conn
+        |> assign(:repository, repository)
+      false ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(ErrorView)
+        |> render("404.html")
+        |> halt()
+    end
+  end
+
 end

--- a/test/funnel_web/controllers/repositories_controller_test.exs
+++ b/test/funnel_web/controllers/repositories_controller_test.exs
@@ -4,7 +4,7 @@ defmodule FunnelWeb.RepositoriesControllerTest do
   import Mock
   alias Funnel.GitHub
 
-  @create_attrs %{git_hub_id: 123456, git_hub_installation_id: 66216}
+  @create_attrs %{git_hub_id: 123456, git_hub_installation_id: 66216, details: %{owner: "ian", name: "cheng"}}
   @update_attrs %{git_hub_id: 654321, details: %{owner: "sara", name: "zac"}}
   @invalid_attrs %{git_hub_id: nil, details: nil}
 
@@ -14,43 +14,100 @@ defmodule FunnelWeb.RepositoriesControllerTest do
   end
 
   describe "index" do
-    test "lists all repositories", %{conn: conn} do
-      with_mocks([
-        {Funnel.Platter, [],
-         [get_all_user_repositories: fn(_) -> [] end]}
-      ]) do
+    setup [:create_session_conn]
+
+    test "redirects when no github access token", %{conn: conn} do
+      with_mocks(platter_mocks(false)) do
         conn = get conn, repositories_path(conn, :index)
         assert html_response(conn, 302)
       end
     end
+
+    test "lists all repositories", %{conn: conn} do
+      with_mocks(platter_mocks(true)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> get(repositories_path(conn, :index))
+        assert html_response(conn, 200) =~ "Repositories"
+      end
+    end
   end
 
-  @tag :skip
   describe "show" do
-    test "shows a repository's info", %{conn: conn} do
-      conn = get conn, repositories_path(conn, :show)
-      assert html_response(conn, 200) =~ "Repositories"
+    setup [:create_session_conn, :create_repository]
+
+    test "404s when user isn't authorized", %{conn: conn, repository: repository} do
+      with_mocks(platter_mocks(false)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> get(repositories_path(conn, :show, repository))
+        assert html_response(conn, 404)
+      end
+    end
+
+    test "shows a repository's info", %{conn: conn, repository: repository} do
+      with_mocks(platter_mocks(true)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> get(repositories_path(conn, :show, repository))
+        assert html_response(conn, 200) =~ @create_attrs.details.owner <> "/" <> @create_attrs.details.name
+      end
     end
   end
 
   describe "edit repository" do
-    setup [:create_repository]
+    setup [:create_session_conn, :create_repository]
+
+    test "404s when user isn't authorized", %{conn: conn, repository: repository} do
+      with_mocks(platter_mocks(false)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> get(repositories_path(conn, :edit, repository))
+        assert html_response(conn, 404)
+      end
+    end
 
     test "renders form for editing chosen repository", %{conn: conn, repository: repository} do
-      conn = get conn, repositories_path(conn, :edit, repository)
-      assert html_response(conn, 200) =~ "Edit Repository"
+      with_mocks(platter_mocks(true)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> get(repositories_path(conn, :edit, repository))
+        assert html_response(conn, 200) =~ "Edit Repository"
+      end
     end
   end
 
   describe "update repository" do
-    setup [:create_repository]
+    setup [:create_session_conn, :create_repository]
+
+    test "404s when user isn't authorized", %{conn: conn, repository: repository} do
+      with_mocks(platter_mocks(false)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> put(repositories_path(conn, :update, repository), repository: @update_attrs)
+        assert html_response(conn, 404)
+      end
+    end
 
     test "redirects when data is valid", %{conn: conn, repository: repository} do
-      with_mocks([
-        {Funnel.Investigator, [],
-         [investigate_repository: fn(_) -> :ok end]}
-      ]) do
-        conn = put conn, repositories_path(conn, :update, repository), repository: @update_attrs
+      with_mocks(platter_mocks(true)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> put(repositories_path(conn, :update, repository), repository: @update_attrs)
         assert redirected_to(conn) == repositories_path(conn, :show, repository)
 
         conn = get conn, repositories_path(conn, :show, repository)
@@ -59,13 +116,37 @@ defmodule FunnelWeb.RepositoriesControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, repository: repository} do
-      conn = put conn, repositories_path(conn, :update, repository), repository: @invalid_attrs
-      assert html_response(conn, 200) =~ "Edit Repository"
+      with_mocks(platter_mocks(true)) do
+        conn =
+          conn
+          |> fetch_session()
+          |> put_session(:git_hub_access_token, "t0kenstr1ng")
+          |> put(repositories_path(conn, :update, repository), repository: @invalid_attrs)
+        assert html_response(conn, 200) =~ "Edit Repository"
+      end
     end
   end
 
   defp create_repository(_) do
     repository = fixture(:repository)
     {:ok, repository: repository}
+  end
+
+  defp create_session_conn(_) do
+    conn = session_conn()
+    {:ok, conn: conn}
+  end
+
+  defp platter_mocks(has_access) do
+    [
+      {Funnel.Platter, [],
+       [
+         get_all_user_repositories: fn(_) -> [] end,
+         user_has_git_hub_repository_access?: fn(_, _) -> has_access end
+       ]},
+       {Funnel.Investigator, [],
+        [investigate_repository: fn(_) -> :ok end]
+      }
+    ]
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,9 +23,24 @@ defmodule FunnelWeb.ConnCase do
 
       # The default endpoint for testing
       @endpoint FunnelWeb.Endpoint
+
+      # setting up a session configured conn
+      def session_conn() do
+        opts =
+          Plug.Session.init(
+            store: :cookie,
+            key: "foobar",
+            encryption_salt: "encrypted cookie salt",
+            signing_salt: "signing salt",
+            log: false,
+            encrypt: false
+          )
+        build_conn()
+        |> Plug.Session.call(opts)
+        |> fetch_session()
+      end
     end
   end
-
 
   setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Funnel.Repo)


### PR DESCRIPTION
## What I did

### Goals

* ensure that unauthenticated users are asked to login via github
* check if user can is authorized for a given repository (via github) before showing them info about it or letting them edit its funnel settings

### Implementation Details

* added functions to `Platter` for checking if a given user token has access to a given repository
* used plugs to prepend actions in controller with authentication and authorization checks
* used assigns in `Plug.Conn` to simplify `show`, `edit`, and `update`

## Notes
* used plugs! similar to https://hexdocs.pm/phoenix/plug.html#function-plugs
* test modelled after https://gist.github.com/outofambit/ed5f33a7ad18e2d7be9aee8d95eb440a

