### PR TITLE
unknown event handling in events controller

### DIFF
--- a/lib/funnel/scent.ex
+++ b/lib/funnel/scent.ex
@@ -30,6 +30,10 @@ defmodule Funnel.Scent do
     case event_type do
       "push" -> get_scent_from_push(params)
       "pull_request" -> get_scent_from_pull_request(params)
+      _ ->
+        require Logger
+        Logger.debug("Unkown event type: " <> event_type)
+        nil
     end
   end
 

--- a/lib/funnel_web/controllers/events_controller.ex
+++ b/lib/funnel_web/controllers/events_controller.ex
@@ -3,9 +3,19 @@ defmodule FunnelWeb.EventsController do
   alias Funnel.Investigator
 
   def receive(conn, _params) do
-    Funnel.Scent.get_scent(conn.body_params, List.first(get_req_header(conn, "x-github-event")))
-    |> Investigator.investigate()
-    text conn, "Thanks!"
+    case Funnel.Scent.get_scent(conn.body_params, List.first(get_req_header(conn, "x-github-event"))) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> text("Huh?")
+        |> halt()
+      scent ->
+        Investigator.investigate(scent)
+        conn
+        |> put_status(:ok)
+        |> text("Thanks!")
+    end
+
   end
 
 end

--- a/test/funnel_web/controllers/events_controller_test.exs
+++ b/test/funnel_web/controllers/events_controller_test.exs
@@ -4,13 +4,24 @@ defmodule FunnelWeb.EventsControllerTest do
   import Funnel.Factory
   import Mock
 
-  test "post /api/events", %{conn: conn} do
-    with_mocks([
-      {Funnel.Investigator, [], [investigate: fn(_) -> :noop end]},
-      {Funnel.Scent, [], [get_scent: fn(_,_) -> build(:good_push_scent) end]},
-    ]) do
-      conn = post conn, "/api/events"
-      assert response(conn, 200) =~ "Thanks!"
+  describe "receive" do
+    test "pull request event", %{conn: conn} do
+      with_mocks([
+        {Funnel.Investigator, [], [investigate: fn(_) -> :ok end]},
+        {Funnel.Scent, [], [get_scent: fn(_,_) -> build(:good_push_scent) end]},
+      ]) do
+        conn = post(conn, events_path(conn, :receive))
+        assert response(conn, 200) =~ "Thanks!"
+      end
+    end
+    test "unkown event", %{conn: conn} do
+      with_mocks([
+        {Funnel.Investigator, [], [investigate: fn(_) -> :ok end]},
+        {Funnel.Scent, [], [get_scent: fn(_,_) -> nil end]},
+      ]) do
+        conn = post(conn, events_path(conn, :receive))
+        assert response(conn, 404) =~ "Huh?"
+      end
     end
   end
 end


### PR DESCRIPTION
## Goals

avoid the following error:
```
[error] #PID<0.419.0> running FunnelWeb.Endpoint terminated
Server: funnel.ngrok.io:80 (http)
Request: POST /api/events
** (exit) an exception was raised:
    ** (CaseClauseError) no case clause matching: "integration_installation_repositories"
        (funnel) lib/funnel/scent.ex:30: Funnel.Scent.get_scent/2
        (funnel) lib/funnel_web/controllers/events_controller.ex:6: FunnelWeb.EventsController.receive/2
        (funnel) lib/funnel_web/controllers/events_controller.ex:1: FunnelWeb.EventsController.action/2
        (funnel) lib/funnel_web/controllers/events_controller.ex:1: FunnelWeb.EventsController.phoenix_controller_pipeline/2
        (funnel) lib/funnel_web/endpoint.ex:1: FunnelWeb.Endpoint.instrument/4
        (phoenix) lib/phoenix/router.ex:278: Phoenix.Router.__call__/1
        (funnel) lib/funnel_web/endpoint.ex:1: FunnelWeb.Endpoint.plug_builder_call/2
        (funnel) lib/plug/debugger.ex:102: FunnelWeb.Endpoint."call (overridable 3)"/2
        (funnel) lib/funnel_web/endpoint.ex:1: FunnelWeb.Endpoint.call/2
        (plug) lib/plug/adapters/cowboy/handler.ex:16: Plug.Adapters.Cowboy.Handler.upgrade/4
        (cowboy) /Users/evma/src/funnel/deps/cowboy/src/cowboy_protocol.erl:442: :cowboy_protocol.execute/4
```

## Implementation

* catch all for case statement in `get_scent` that returns `nil`
* handle nil return and set error code for response in events controller